### PR TITLE
Dispatch enabling/disabling of TKTDebugger to its process class. Fixe…

### DIFF
--- a/TaskIt/Process.extension.st
+++ b/TaskIt/Process.extension.st
@@ -1,6 +1,16 @@
 Extension { #name : #Process }
 
 { #category : #'*TaskIt' }
+Process class >> disableDebugger [
+	
+]
+
+{ #category : #'*TaskIt' }
+Process class >> enableDebugger [
+	
+]
+
+{ #category : #'*TaskIt' }
 Process class >> isDebuggingCompatible [
 	^ false
 ]

--- a/TaskIt/TKTProfile.class.st
+++ b/TaskIt/TKTProfile.class.st
@@ -89,8 +89,8 @@ TKTProfile >> activateProfile [
 	self debugging
 		ifTrue: [ self options
 				do: [ :option | self assert: (self at: option) isDebuggingCompatible description: ('The option{1} is not debugging compatible! ' format: {option}) ].
-			TKTDebugger enable ]
-		ifFalse: [ TKTDebugger disable ].
+				(self at: #process) enableDebugger ]
+		ifFalse: [ (self at: #process) disableDebugger ].
 	self runner start
 ]
 

--- a/TaskItDebugger/TKTRawProcess.class.st
+++ b/TaskItDebugger/TKTRawProcess.class.st
@@ -17,6 +17,16 @@ Class {
 }
 
 { #category : #configuration }
+TKTRawProcess class >> disableDebugger [
+	TKTDebugger disable
+]
+
+{ #category : #configuration }
+TKTRawProcess class >> enableDebugger [
+	TKTDebugger enable
+]
+
+{ #category : #configuration }
 TKTRawProcess class >> isDebuggingCompatible [
 	^ true
 ]


### PR DESCRIPTION
…s a bug where using a production profile with loading minimal group is not working.

minimal group loads no TKTDebugger which is wanted in production environments. But switching to TKTProfile production invokes enable or disable on TKTDebugger which fails as not present in minimal group