### PR TITLE
service: Register completion handler before stopping

### DIFF
--- a/TaskIt/TKTService.class.st
+++ b/TaskIt/TKTService.class.st
@@ -198,9 +198,9 @@ TKTService >> stepService [
 { #category : #starting }
 TKTService >> stop [
 	| futureStop |
-	stopRequested := true.
 	futureStop := TKTFuture new.
 	self onStoppedDo: [ :v | futureStop deploySuccess: self ].
+	stopRequested := true.
 	TKTConfiguration serviceManager removeService: self.
 	^ futureStop
 ]


### PR DESCRIPTION
Install the completion handler before requesting the worker/scheduler to stop. In theory it was possible for the recursive scheduling to finish without calling the completion handler.