### PR TITLE
Speed-up stopping a service

### DIFF
--- a/TaskIt/TKTService.class.st
+++ b/TaskIt/TKTService.class.st
@@ -66,10 +66,10 @@ Class {
 	#instVars : [
 		'worker',
 		'stopRequested',
-		'stopCallback',
 		'stopCallbacks',
 		'stepDelay',
-		'recursiveTask'
+		'recursiveTask',
+		'currentDelay'
 	],
 	#category : #'TaskIt-Services'
 }
@@ -99,7 +99,8 @@ TKTService >> isRunning [
 { #category : #stepping }
 TKTService >> iterateService [
 	self stepService.
-	stepDelay wait
+	currentDelay := stepDelay asDelay.
+	currentDelay wait
 ]
 
 { #category : #private }
@@ -202,6 +203,7 @@ TKTService >> stop [
 	self onStoppedDo: [ :v | futureStop deploySuccess: self ].
 	stopRequested := true.
 	TKTConfiguration serviceManager removeService: self.
+	currentDelay ifNotNil: [:delay | delay delaySemaphore signal ].
 	^ futureStop
 ]
 


### PR DESCRIPTION
Don't wait for the next step before terminating. As best effort signal the delay semaphore to wake up early. Stores might not be atomic and we signal the last delays semaphore but that is fine and we just have to wait the full delay. This is mostly about fast shutdown during tests